### PR TITLE
Fixed loading times for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "scripts": {
     "start": "nodemon server/index.js",
-    "build": "webpack --watch",
+    "dev": "webpack --config webpack.config.js --watch --mode=development",
+    "build-client": "webpack",
     "test": "jest src"
   },
   "repository": {


### PR DESCRIPTION
Use npm run dev for dev mode, and npm build-client before pushing to final production.

@xanzadu @solo917 